### PR TITLE
ios 7 key commands part 2

### DIFF
--- a/iBrogue_iPad/ViewController.h
+++ b/iBrogue_iPad/ViewController.h
@@ -16,7 +16,10 @@ extern Viewport *theMainDisplay;
 extern ViewController *viewController;
 
 @interface ViewController : UIViewController {
+    @private
     NSMutableArray *_commands;
+    @private
+    NSDictionary *_keyCommandsTranslator;
 }
 
 struct iBTouch {


### PR DESCRIPTION
It works only on ios7 but it don't crash on ios6 (it simply ignores the new keyCommand function).

I've added more key commands. The only missing one it's shift+key direction that i don't know what is for.
