### PR TITLE
SE: cursed-runics — Smoky armor progressive per-enchant sight

### DIFF
--- a/BrogueSE/Engine/IOS_MODIFICATIONS.md
+++ b/BrogueSE/Engine/IOS_MODIFICATIONS.md
@@ -32,6 +32,31 @@ See `BrogueCE/Engine/IOS_MODIFICATIONS.md` (faithful CE) and
 
 ## Change log
 
+### 2026-07-02 — Cursed-runics: Smoky armor progressive per-enchant sight (post-0.12.0)
+
+**Why.** The cursed Smoky armor's 1-tile blindness was too punishing to *live* with — fine as an opening
+handicap, but it made exploration (finding scrolls of enchanting, etc.) miserable in a dungeon you can't
+see. The rework makes the blindness **ease with every enchant** on the way to the +4 purify, so investment
+is felt continuously rather than only at the finish.
+
+**What.** `emitSmokyArmorCloud()` (`Time.c`) no longer wreathes all 8 neighbors in thick, sight-blocking
+smoke. It now **dithers**: `clearCount` of the 8 neighbors are thinned to sub-threshold smoke
+(`SMOKY_DITHER_THIN_VOLUME` = 10 < `SMOKE_THICK_VOLUME`), which dims but does not block — and clearing a
+neighbor opens the whole sightline past it. The easing is **symmetric** (an open lane lets foes see *in* as
+well), so cursed-Smoky stays a worse deal than the purified +3 stealth aura and never becomes free invisibility.
+
+- **Curve** (`clearByTier`, indexed by `enchant1 + 1`): `-1 → 0` (byte-identical to the old full blindness),
+  `0 → 2`, `+1 → 4`, `+2 → 5`, `+3 → 6` (capped below 8 so +3 still bites). `+4` purifies (cloud gone + the
+  stealth aura, unchanged).
+- **Which cells clear:** `smokyCellHash(x,y)` — a pure, world-anchored spatial hash (no RNG) — ranks the 8
+  neighbors; the `clearCount` lowest are thinned. The lowest-N set ⊂ lowest-(N+1), so enchanting only *adds*
+  lanes (monotonic, no reshuffle), and the open lanes drift organically as you move.
+- **Determinism:** pure functions of `enchant1` and cell `(x,y)`, recomputed each turn — no new save fields,
+  no substantive/cosmetic RNG, replay-safe. Re-stamped at both existing call sites (top-of-turn for monster
+  concealment; pre-vision for the player's FOV) so `updateEnvironment` gas-averaging can't wash out the pattern.
+- **Tuning constant** (`Rogue.h`): `SMOKY_DITHER_THIN_VOLUME`. Info-panel copy for cursed A_SMOKY (`Items.c`)
+  updated to describe the haze thinning per enchant.
+
 ### 2026-07-02 — Brogue SE 0.12.0 "C is for Curses": release cut (version + release notes)
 
 **What.** Cut the 0.12.0 release. Headline features since 0.11.0: the **cursed-runics rework** (double-edged

--- a/BrogueSE/Engine/Items.c
+++ b/BrogueSE/Engine/Items.c
@@ -2727,7 +2727,7 @@ void itemDetails(char *buf, item *theItem) {
                             case A_SMOKY:
                                 // iOS port (Brogue SE): cursed-runics rework -- describe by purify state.
                                 if (theItem->enchant1 < ARMOR_RUNIC_PURIFY_ENCHANT) {
-                                    sprintf(buf2, "When worn it wreathes you in thick smoke: creatures more than a step away cannot see you -- you move unseen and can strike the unwary -- but your own sight collapses to your immediate surroundings. Enchant it to +%i to purify: the choking smoke refines into a subtle stealth, so you move unseen and unheard while seeing clearly. ", ARMOR_RUNIC_PURIFY_ENCHANT);
+                                    sprintf(buf2, "When worn it wreathes you in thick smoke: creatures more than a step away cannot see you -- you move unseen and can strike the unwary -- but your own sight collapses to your immediate surroundings. Each enchantment thins the haze further, opening more sightlines (though what you can see through, foes can too). Enchant it to +%i to purify: the smoke refines into a subtle stealth, so you move unseen and unheard while seeing clearly. ", ARMOR_RUNIC_PURIFY_ENCHANT);
                                 } else {
                                     strcpy(buf2, "When worn you move like smoke -- a subtle stealth that leaves you both harder to see and quieter, with no cost to your own sight. ");
                                 }

--- a/BrogueSE/Engine/Rogue.h
+++ b/BrogueSE/Engine/Rogue.h
@@ -1340,6 +1340,7 @@ enum armorEnchants {
 #define ANCHOR_DEFENSE_BONUS            30  // +defense (x10 units; +3 displayed) while worn -- always on
 #define ANCHOR_MOVE_SLOW_PCT           100  // extra % move-cost while cursed (100 = double); attacks untouched
 #define SMOKY_STEALTH_BONUS            3   // purified Smoky's passive stealth (spot + noise); ~a +3 ring of stealth
+#define SMOKY_DITHER_THIN_VOLUME      10  // cleared-lane smoke volume while cursed: below SMOKE_THICK_VOLUME, so it dims but doesn't block sight (progressive per-enchant sight)
 
 enum wandKind {
     WAND_TELEPORT,

--- a/BrogueSE/Engine/RogueMain.c
+++ b/BrogueSE/Engine/RogueMain.c
@@ -610,15 +610,15 @@ void initializeRogue(uint64_t seed) {
         // loop: identify (reveal the runic), enchanting (reach +6 to purify), and remove-curse (eject ->
         // shatter). Deterministic/replay-safe.
         theItem = generateItem(SCROLL, SCROLL_ENCHANTING);
-        theItem->quantity = 12;
-        identify(theItem);
-        theItem = addItemToPack(theItem);
-        theItem = generateItem(SCROLL, SCROLL_IDENTIFY);
         theItem->quantity = 5;
         identify(theItem);
         theItem = addItemToPack(theItem);
+        theItem = generateItem(SCROLL, SCROLL_IDENTIFY);
+        theItem->quantity = 1;
+        identify(theItem);
+        theItem = addItemToPack(theItem);
         theItem = generateItem(SCROLL, SCROLL_REMOVE_CURSE);
-        theItem->quantity = 3;
+        theItem->quantity = 1;
         identify(theItem);
         theItem = addItemToPack(theItem);
     }

--- a/BrogueSE/Engine/Time.c
+++ b/BrogueSE/Engine/Time.c
@@ -2663,20 +2663,68 @@ static void recordCurrentCreatureHealths() {
 // Refreshed on the player + 8 neighbors (the minimal cloud that hides you from every non-adjacent
 // monster); cells you leave dissipate into a short trail (escape cover). Never clobbers another gas,
 // skips gas-blocking terrain, draws no RNG (replay-safe). Purify swaps this for a passive stealth aura.
+// iOS port (Brogue SE): world-anchored spatial hash (no RNG) -- ranks the Smoky armor's neighbor
+// cells so the haze thins the same cells first for a given position. Any stable mix of (x,y) works;
+// this one scatters adjacent cells well so the open lanes don't clump.
+static unsigned long smokyCellHash(short x, short y) {
+    unsigned long h = (unsigned long)((int)x * 73856093) ^ (unsigned long)((int)y * 19349663);
+    h ^= (h >> 13);
+    h *= 0x5bd1e995UL;
+    h ^= (h >> 15);
+    return h;
+}
+
 static void emitSmokyArmorCloud(void) {
     if (!(rogue.armor && (rogue.armor->flags & ITEM_RUNIC) && rogue.armor->enchant2 == A_SMOKY
           && runicCurseActive(rogue.armor))) {
         return;
     }
-    const short dirs[9][2] = {{0,0},{-1,-1},{0,-1},{1,-1},{-1,0},{1,0},{-1,1},{0,1},{1,1}};
-    for (short d = 0; d < 9; d++) {
-        short cx = player.loc.x + dirs[d][0], cy = player.loc.y + dirs[d][1];
+    // iOS port (Brogue SE): cursed-runics rework -- progressive per-enchant sight. Rather than
+    // wreathing all 8 neighbors in thick, sight-blocking smoke, we thin `clearCount` of them into
+    // wispy (sub-threshold) smoke that lets sight pass BOTH ways (symmetric: you see out, foes see
+    // in). Clearing a neighbor opens the whole sightline past it, so a couple of open lanes restores
+    // real exploration. The cursed enchant range is -1..+3 (ARMOR_RUNIC_PURIFY_ENCHANT purifies at
+    // +4); relief is front-loaded and capped below 8 so +3 still bites. Deterministic (pure functions
+    // of enchant1 and cell (x,y)); recomputed each turn, so no save fields and no replay drift.
+    static const short clearByTier[5] = {0, 2, 4, 5, 6}; // index = enchant1 + 1, for enchant1 -1..+3
+    const short clearCount = clearByTier[clamp((short)(rogue.armor->enchant1 + 1), 0, 4)];
+
+    const short dirs[8][2] = {{-1,-1},{0,-1},{1,-1},{-1,0},{1,0},{-1,1},{0,1},{1,1}};
+    unsigned long hash[8];
+    short order[8];
+    for (short d = 0; d < 8; d++) {
+        hash[d] = smokyCellHash(player.loc.x + dirs[d][0], player.loc.y + dirs[d][1]);
+        order[d] = d;
+    }
+    // Rank the 8 neighbors by hash and thin the `clearCount` lowest (tiny fixed-n selection sort).
+    // The lowest-N set is a subset of the lowest-(N+1) set, so enchanting only ever ADDS open lanes
+    // (never reshuffles), and the lanes drift organically as the (world-anchored) neighbor coords change.
+    for (short a = 0; a < clearCount; a++) {
+        for (short b = a + 1; b < 8; b++) {
+            if (hash[order[b]] < hash[order[a]]) {
+                const short t = order[a]; order[a] = order[b]; order[b] = t;
+            }
+        }
+    }
+    boolean thin[8] = {false};
+    for (short k = 0; k < clearCount && k < 8; k++) {
+        thin[order[k]] = true;
+    }
+
+    // Stamp own cell (always thick -- doesn't blind outbound sight, since the block is on seeing PAST
+    // a cell) plus the 8 neighbors (thick or thinned per the dither). Re-stamped every turn at both
+    // call sites so gas-averaging in updateEnvironment can't wash the pattern below/above the threshold.
+    for (short d = -1; d < 8; d++) {
+        const short cx = player.loc.x + (d < 0 ? 0 : dirs[d][0]);
+        const short cy = player.loc.y + (d < 0 ? 0 : dirs[d][1]);
         if (!coordinatesAreInMap(cx, cy)) continue;
         if (cellHasTerrainFlag((pos){ cx, cy }, T_OBSTRUCTS_GAS)) continue;
         if (pmap[cx][cy].layers[GAS] != NOTHING && pmap[cx][cy].layers[GAS] != SMOKE_GAS) continue;
         pmap[cx][cy].layers[GAS] = SMOKE_GAS;
-        if (pmap[cx][cy].volume < SMOKE_THICK_VOLUME + 6) {
-            pmap[cx][cy].volume = SMOKE_THICK_VOLUME + 6; // comfortably thick; survives a turn of dissipation
+        if (d >= 0 && thin[d]) {
+            pmap[cx][cy].volume = SMOKY_DITHER_THIN_VOLUME;   // open lane: dims but does not block sight
+        } else if (pmap[cx][cy].volume < SMOKE_THICK_VOLUME + 6) {
+            pmap[cx][cy].volume = SMOKE_THICK_VOLUME + 6;     // comfortably thick; survives a turn of dissipation
         }
         refreshDungeonCell((pos){ cx, cy });
     }


### PR DESCRIPTION
The cursed Smoky armor's flat 1-tile blindness was too punishing to live with (fine as an opening handicap, miserable for exploration). It now eases with every enchant on the way to the +4 purify.

- emitSmokyArmorCloud() (Time.c) dithers instead of blanketing all 8 neighbors in thick, sight-blocking smoke: clearCount of them are thinned to sub-threshold smoke (SMOKY_DITHER_THIN_VOLUME = 10 < SMOKE_THICK_VOLUME), which dims but does not block -- and clearing a neighbor opens the whole sightline past it.
- Symmetric: an open lane lets foes see IN as well, so cursed-Smoky stays a worse deal than the purified +3 stealth aura and never becomes free invisibility.
- Curve clearByTier {0,2,4,5,6} for enchant -1..+3: -1 is byte-identical to the old full blindness, +3 caps at 6/8 so it still bites; +4 purify unchanged.
- Which cells clear: smokyCellHash(x,y), a pure world-anchored hash (no RNG), ranks the 8 neighbors and thins the lowest N; lowest-N ⊂ lowest-(N+1), so enchanting only ADDS lanes (monotonic, no reshuffle), and lanes drift organically as you move. Deterministic/ replay-safe; re-stamped at both call sites so updateEnvironment gas-averaging can't wash the pattern out.
- SMOKY_DITHER_THIN_VOLUME (Rogue.h); cursed A_SMOKY info-panel copy updated (Items.c); logged in IOS_MODIFICATIONS.md.

Also trims the curse-test debug grant quantities (enchanting 12->5, identify/remove-curse ->1); debug-only (D_CURSE_TEST_SCROLLS_START defaults 0), no effect on normal play.