### PR TITLE
Fix save/replay desync from the rest-interrupt hearing roll (0.12.1 OOS)

### DIFF
--- a/BrogueSE/Engine/Combat.c
+++ b/BrogueSE/Engine/Combat.c
@@ -1400,13 +1400,16 @@ static short weaponMeleeLoudness(const item *weapon, boolean connected) {
 // since every message() sets rogue.disturbed. First tell of a session still interrupts (real
 // information); repeats during the same session are suppressed until the player takes a non-rest
 // action (rogue.heardDistantCombatThisRest, cleared in the playerTurnEnded session sweep alongside
-// MB_HEARD_THIS_REST). No RNG; replay-deterministic.
+// MB_HEARD_THIS_REST). No RNG; replay-deterministic. Gated on justRested only, NOT automationActive:
+// playback replays autoRest as plain REST_KEY turns with automationActive unset, so an automation gate
+// would suppress live but not on replay (message-only here, but keep record/replay behavior aligned --
+// same pitfall that desynced the rest-listening roll in Monsters.c).
 static void distantCombatTell(void) {
     if (rogue.heardCombatThisTurn) {
         return;
     }
     rogue.heardCombatThisTurn = true;
-    if (rogue.automationActive && rogue.justRested) { // inside a 'Z' rest turn
+    if (rogue.justRested) { // inside a rest turn ('z' or 'Z')
         if (rogue.heardDistantCombatThisRest) {
             return; // this session already got its one ambient-combat interrupt
         }

--- a/BrogueSE/Engine/Monsters.c
+++ b/BrogueSE/Engine/Monsters.c
@@ -5278,14 +5278,19 @@ void playerEmitNoise(short spike) { (void)spike; rogue.playerNoise = NOISE_PLAYE
 // closed door. Additive (not a multiplicative loudness scalar) so awareness can compensate for a quiet
 // monster.
 //
-// RNG SPLIT (hearing-interrupts-rest, 2026-07-22): during a LONG-REST turn ('Z': rogue.automationActive
-// && rogue.justRested) a hostile monster's roll is SUBSTANTIVE -- a success INTERRUPTS the rest (tier-
-// flavored message + ripple + haptic), so the outcome drives gameplay and must replay identically. One
-// interrupt per monster per rest session (MB_HEARD_THIS_REST; cleared on any non-rest action in
-// playerTurnEnded): re-resting past a ping is an informed gamble, and a worshiper's endless clamor stops
-// nagging after its first wake. Allies/captives never interrupt. Everywhere else the roll stays
-// RNG_COSMETIC (informational ripple only), so noise tuning never desyncs normal-play saves/replays or
-// seeds -- only rest-context behavior is version-locked. See docs/design/noise-system.md.
+// RNG SPLIT (hearing-interrupts-rest, 2026-07-22; replay fix 2026-07-23): during ANY rest turn
+// (rogue.justRested -- a single 'z' or one turn of a 'Z' autoRest) a hostile monster's roll is
+// SUBSTANTIVE -- a success INTERRUPTS the rest (tier-flavored message + ripple + haptic), so the
+// outcome drives gameplay and must replay identically. The gate MUST NOT read rogue.automationActive:
+// autoRest records each turn as a plain REST_KEY (indistinguishable from 'z' in the recording), and
+// playback replays those through executeKeystroke where automationActive is never set -- so a gate on
+// it draws substantive RNG live but not on replay, desyncing every save that rested near an unseen
+// hostile (the 0.12.1 out-of-sync bug). Only state that playback reconstructs identically (justRested,
+// creatureState, bookkeepingFlags) may pick the stream. One interrupt per monster per rest session
+// (MB_HEARD_THIS_REST; cleared on any non-rest action in playerTurnEnded): re-resting past a ping is an
+// informed gamble, and a worshiper's endless clamor stops nagging after its first wake. Allies/captives
+// never interrupt. Everywhere else the roll stays RNG_COSMETIC (informational ripple only), so noise
+// tuning never desyncs normal-play saves/replays or seeds. See docs/design/noise-system.md.
 static void monsterEmitMovementNoise(creature *monst, short originX, short originY) {
 #if NOISE_SYSTEM_ENABLED
     if (monst == &player) {
@@ -5337,9 +5342,10 @@ static void monsterEmitMovementNoise(creature *monst, short originX, short origi
         // Global A/B playtest scalar (NOISE_PERCEPTION_SCALE: 100 = baseline, <100 quieter, >100 louder).
         detectChance = clamp((detectChance * NOISE_PERCEPTION_SCALE) / 100, 0, NOISE_PERCEPTION_CEILING);
 
-        // Hearing-interrupts-rest: on a long-rest turn, a hostile that hasn't already broken this rest
+        // Hearing-interrupts-rest: on a rest turn, a hostile that hasn't already broken this rest
         // session rolls on the SUBSTANTIVE stream, because a success ends the rest (see header comment).
-        const boolean restListening = rogue.automationActive && rogue.justRested   // inside a 'Z' rest turn
+        // NOT gated on rogue.automationActive: playback never reconstructs it (see header comment).
+        const boolean restListening = rogue.justRested                             // inside a rest turn ('z' or 'Z')
                                     && monst->creatureState != MONSTER_ALLY        // hostiles only
                                     && !(monst->bookkeepingFlags & MB_CAPTIVE)
                                     && !(monst->bookkeepingFlags & MB_HEARD_THIS_REST);

--- a/BrogueSE/Engine/Rogue.h
+++ b/BrogueSE/Engine/Rogue.h
@@ -178,9 +178,12 @@
 //
 // NOISE_PERCEPTION_SCALE is the single A/B tuning lever: 100 = baseline, <100 toward lucky-roll, >100
 // toward generous -- slide the whole ringless feel without re-deriving every constant.
-// RNG SPLIT (hearing-interrupts-rest, 2026-07-22): during a LONG-REST turn ('Z' automation) the roll is
-// SUBSTANTIVE -- a successful hear interrupts the rest (one interrupt per monster per session, hostiles
-// only; see MB_HEARD_THIS_REST), so the outcome drives gameplay and must replay identically. Everywhere
+// RNG SPLIT (hearing-interrupts-rest, 2026-07-22; replay fix 2026-07-23): during ANY rest turn
+// (rogue.justRested: single 'z' or a 'Z' autoRest turn) the roll is SUBSTANTIVE -- a successful hear
+// interrupts the rest (one interrupt per monster per session, hostiles only; see MB_HEARD_THIS_REST),
+// so the outcome drives gameplay and must replay identically. The gate deliberately does NOT read
+// rogue.automationActive: playback replays autoRest as plain REST_KEY turns with it unset, so an
+// automation gate draws substantive RNG live but not on replay -- the 0.12.1 out-of-sync bug. Everywhere
 // else the roll stays RNG_COSMETIC (informational ripple only), so tuning these constants still never
 // desyncs normal-play recordings or seeds -- only rest-context behavior is version-locked (recording
 // version gates compat). See monsterEmitMovementNoise, docs/design/noise-system.md, PERCEPTION_AUDIT.md.
@@ -291,10 +294,10 @@
 #define NOISE_DOOR_LISTEN_RANGE         4   // audible-radius tiles added while at a door (hear through it)
 #define NOISE_REST_PERCEPTION_BONUS     6   // detection bonus while resting (listening intently). Applies
                                             // whenever rogue.justRested: live on a short 'z' (ripple animates
-                                            // with the boost) AND on long rest 'Z', where a successful hear now
-                                            // INTERRUPTS the rest (message + ripple + haptic; substantive roll,
-                                            // one interrupt per monster per session -- see MB_HEARD_THIS_REST
-                                            // and monsterEmitMovementNoise). Landed 2026-07-22.
+                                            // with the boost) AND on any rest turn ('z' or 'Z'), where a successful
+                                            // hear now INTERRUPTS the rest (message + ripple + haptic; substantive
+                                            // roll, one interrupt per monster per session -- see MB_HEARD_THIS_REST
+                                            // and monsterEmitMovementNoise). Landed 2026-07-22; replay fix 07-23.
 // Terrain EMISSION: how much the terrain a creature steps into adds to / dampens the noise of that step
 // (distinct from the sound map's propagation damping above). Signed, smaller than the monster tiers since
 // it only modulates on top. Read at the destination cell (terrainNoiseModifier). Direction-agnostic.


### PR DESCRIPTION
The hearing-interrupts-rest roll picked its RNG stream via rogue.automationActive && rogue.justRested. autoRest records each rest turn as a plain REST_KEY event, and playback replays those through executeKeystroke, which sets justRested but never automationActive -- so live play drew a substantive rand_percent for every eligible unseen-hostile step during a 'Z' rest while playback drew none, and the per-turn RNGCheck failed ("Playback is out of sync") at the first such turn. Longer runs rest more, hence the report skew toward long games.

Gate on rogue.justRested alone: it is reconstructed identically during playback, and it makes a single 'z' a genuine stop-and-listen action. Align distantCombatTell()'s once-per-rest suppression (message-only) the same way so replays don't print tells the live game suppressed.

Rule going forward, now documented at the gate and in docs/design/noise-system.md: an RNG-stream choice may only read state that playback reconstructs identically (justRested, creatureState, bookkeepingFlags), never live-session automation state.

Reproduced with a scripted record->replay harness on the desktop port (seed 1, wizard, 40x 'Z'): live drew 6 substantive rolls, replay panicked at the first (turn 48). Fixed build replays the same recording cleanly.